### PR TITLE
Update to v 0.3.0

### DIFF
--- a/gen/utils.v
+++ b/gen/utils.v
@@ -18,10 +18,10 @@ fn translate_type(gl string) string {
 		'GLuint' { 'u32' }
 		'GLint' { 'int' }
 		'GLsizei' { 'int' }
-		'GLboolean' { 'byte' }
+		'GLboolean' { 'u8' }
 		'GLbyte' { 'i8' }
 		'GLshort' { 'i16' }
-		'GLubyte' { 'byte' }
+		'GLubyte' { 'u8' }
 		'GLushort' { 'u16' }
 		'GLulong' { 'u64' }
 		'GLfloat' { 'f32' }
@@ -70,6 +70,9 @@ fn unreserve_word(raw string) string {
 // invalid in V.
 // inevitably O(n^2), probably a performance pain point.
 fn is_invalid(name string) bool {
+	if name[0..1].is_upper() {
+		return true
+	}
 	for reserved in gen.reserved_numbers {
 		if name.starts_with(reserved) {
 			return true
@@ -103,7 +106,7 @@ enum SnakeCaseParserPrev {
 	number
 }
 
-fn (mut prev SnakeCaseParserPrev) set(c byte) {
+fn (mut prev SnakeCaseParserPrev) set(c u8) {
 	if c.is_digit() {
 		prev = .number
 		return
@@ -125,7 +128,7 @@ fn to_snake_case(camel_case string, ignore_starting_capital bool) string {
 	// 1. if capital, insert underscore and lowercase
 	// 2. if capital after number, only lowercase
 	// 3. if multiple capitals right after each other, first an underscore and lowercase, then only lowercase
-	mut res := []byte{cap: camel_case.len}
+	mut res := []u8{cap: camel_case.len}
 
 	mut prev := if ignore_starting_capital {
 		SnakeCaseParserPrev.capital
@@ -159,15 +162,15 @@ fn validify_enum(val string) string {
 
 fn make_sure_dir_exists(path string) ? {
 	if !os.exists(path) {
-		os.mkdir(path) ?
+		os.mkdir(path)?
 	}
 }
 
 fn string_index_last(str string, find string) ?int {
-	return str.len - (str.reverse().index(find.reverse()) ? + find.len)
+	return str.len - (str.reverse().index(find.reverse())? + find.len)
 }
 
-fn string_count(str string, find byte) int {
+fn string_count(str string, find u8) int {
 	mut count := 0
 	for b in str.bytes() {
 		if b == find {

--- a/sys/bindings.v
+++ b/sys/bindings.v
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a5864b97418212a34f600f32f658bdd86a9219381f5a611890c45df29d8848e3
-size 408168
+oid sha256:ddc7d84480265248ae0124a221fb0cee47b28d7c7a01e126cfd1e0ee7bdc4841
+size 385343

--- a/sys/enums.v
+++ b/sys/enums.v
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:40fab9b6687ddfe514b37c0fe2c415544963c56db016f829997abbec2b30b2da
-size 270400
+oid sha256:a2257614ec8048ffbbde988eba00229af99b025aeff0cb3bf5dc83305293caa8
+size 240406

--- a/sys/fns.v
+++ b/sys/fns.v
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1401a00687fd936942324d259c4a6be722d7b85889c6df1b29d6daa756e78cbd
-size 204285
+oid sha256:7bb8b386c957ca7b5d042885cc74b9cac8a9b9230cb194e4c532ca1f74e96374
+size 192530

--- a/test_app/test.v
+++ b/test_app/test.v
@@ -89,8 +89,8 @@ const (
 )
 
 fn main() {
-	win := create_window() ?
-	init_glew() ?
+	win := create_window()?
+	init_glew()?
 
 	gl.viewport(0, 0, width, height)
 
@@ -111,7 +111,7 @@ fn main() {
 	gl.vertex_attrib_pointer(0, 3, gl.float, gl.gl_false, 3 * 4, voidptr(0))
 	gl.enable_vertex_attrib_array(0)
 
-	prog := load_shaders('./test_app/vert.glsl', './test_app/frag.glsl') ?
+	prog := load_shaders('./test_app/vert.glsl', './test_app/frag.glsl')?
 
 	for C.glfwWindowShouldClose(win) == 0 {
 		gl.clear_color(0.2, 0.3, 0.3, 1.0)
@@ -153,21 +153,21 @@ fn init_glew() ? {
 }
 
 fn load_shaders(vert_path string, frag_path string) ?u32 {
-	vert_src := os.read_file(vert_path) ?
-	frag_src := os.read_file(frag_path) ?
+	vert_src := os.read_file(vert_path)?
+	frag_src := os.read_file(frag_path)?
 
 	vert := gl.create_shader(gl.vertex_shader)
 	frag := gl.create_shader(gl.fragment_shader)
 
-	compile_single_shader(vert_path, vert_src, vert) ?
-	compile_single_shader(frag_path, frag_src, frag) ?
+	compile_single_shader(vert_path, vert_src, vert)?
+	compile_single_shader(frag_path, frag_src, frag)?
 
 	prog := gl.create_program()
 	gl.attach_shader(prog, vert)
 	gl.attach_shader(prog, frag)
 	gl.link_program(prog)
 
-	single_shader_log('', prog, true) ?
+	single_shader_log('', prog, true)?
 
 	gl.delete_shader(vert)
 	gl.delete_shader(frag)
@@ -179,7 +179,7 @@ fn compile_single_shader(path string, src string, shader u32) ? {
 	gl.shader_source(shader, 1, &src.str, voidptr(0))
 	gl.compile_shader(shader)
 
-	single_shader_log(path, shader, false) ?
+	single_shader_log(path, shader, false)?
 }
 
 fn single_shader_log(path string, shader u32, prog bool) ? {
@@ -198,7 +198,7 @@ fn single_shader_log(path string, shader u32, prog bool) ? {
 			gl.get_programiv(shader, gl.info_log_length, &mut log_l)
 		}
 
-		mut b := []byte{len: log_l}
+		mut b := []u8{len: log_l}
 		if !prog {
 			gl.get_shader_info_log(shader, log_l, voidptr(0), b.data)
 		} else {


### PR DESCRIPTION
This PR updates the generator and example to V version 0.3.0.

Specifically:
* `byte` has been changed to `u8`
* `v fmt` changed placement of question marks
* Carriage returns have been stripped (from `glew.h`) which caused problems parsing constants
* Variable names starting in an upper-case character (e.g. `GLsync`) have been made invalid so they now convert to `gl_*`